### PR TITLE
Add Windows Terminal Profiles package to contributions

### DIFF
--- a/_sources/contributions.rst.txt
+++ b/_sources/contributions.rst.txt
@@ -161,6 +161,13 @@ like ``shutdown``, ``hibernate``, ``sleep``, ``restart``, ``lock``, ``logout``,
 ``trash``, ``emptytrash``, ... |br|
 Source: `<https://github.com/psistorm/keypirinha-systemcommands>`_
 
+Terminal-Profiles
+-----------------
+
+:ghu:`fran-f`'s package to list and open
+`Windows Terminal <https://github.com/microsoft/terminal/>` profiles. |br|
+Source: `<https://github.com/fran-f/keypirinha-terminal-profiles>`_
+
 Time
 ----
 


### PR DESCRIPTION
Add a new entry in the third-party package list, pointing to https://github.com/fran-f/keypirinha-terminal-profiles